### PR TITLE
[FIX] Check for definition of the pillars

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -40,7 +40,6 @@ provisioner:
 
 platforms:
   - name: freebsd-10.4
-  - name: freebsd-11.1
   - name: freebsd-11.2
 
 suites:

--- a/freebsd/init.sls
+++ b/freebsd/init.sls
@@ -2,25 +2,25 @@
 
 {%- if pillar.freebsd is defined %}
 include:
-{%- if pillar.freebsd.audit.enabled %}
+  {%- if pillar.freebsd.audit is defined %}
   - freebsd.audit
-{%- endif %}
-{%- if pillar.freebsd.kernel.enabled %}
+  {%- endif %}
+  {%- if pillar.freebsd.kernel is defined %}
   - freebsd.kernel
-{%- endif %}
-{%- if pillar.freebsd.networking is defined %}
+  {%- endif %}
+  {%- if pillar.freebsd.networking is defined %}
   - freebsd.networking
-{%- endif %}
-{%- if pillar.freebsd.newsyslog.enabled %}
+  {%- endif %}
+  {%- if pillar.freebsd.newsyslog is defined %}
   - freebsd.newsyslog
-{%- endif %}
-{%- if pillar.freebsd.periodic.enabled %}
+  {%- endif %}
+  {%- if pillar.freebsd.periodic is defined %}
   - freebsd.periodic
-{%- endif %}
-{%- if pillar.freebsd.repositories %}
+  {%- endif %}
+  {%- if pillar.freebsd.repositories is defined %}
   - freebsd.repositories
-{%- endif %}
-{%- if pillar.freebsd.sysctl.enabled %}
+  {%- endif %}
+  {%- if pillar.freebsd.sysctl is defined %}
   - freebsd.sysctl
-{%- endif %}
+  {%- endif %}
 {%- endif %} {# if pillar.freebsd is defined #}

--- a/freebsd/networking.sls
+++ b/freebsd/networking.sls
@@ -34,7 +34,7 @@ freebsd_networking_dns_config:
   file.managed:
     - name: /etc/resolv.conf
     - mode: 0644
-    - owner: root
+    - user: root
     - group: wheel
     - contents:
       {% if networking.dns.search is defined %}


### PR DESCRIPTION
Fix pillars check definitions and change the deprecated option `owner` to `user`. Also removed FreeBSD 11.1 since we are doing 11.2.