### PR TITLE
Split networking restart

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -40,8 +40,8 @@ provisioner:
         - <%= formula_name %>
 
 platforms:
-  - name: freebsd-10.4
   - name: freebsd-11.2
+  - name: freebsd-12.0
 
 suites:
   - name: default

--- a/freebsd/macros.jinja
+++ b/freebsd/macros.jinja
@@ -17,5 +17,5 @@ freebsd_networking_ifconfig_{{ interface }}:
     - value: "inet {{ interface_cfg }}"
     {% endif -%}
     - onchanges_in:
-      - cmd: freebsd_networking_restart
+      - cmd: freebsd_interfaces_restart
 {%- endmacro %}


### PR DESCRIPTION
This PR changed:

- removed FreeBSD 10.4 and added 12.0
- do not restart interfaces when routing changed, just restart routing
- restart interfaces only when changed 