### PR TITLE
Update .kitchen.yml

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,7 +14,7 @@ driver:
 provisioner:
   name: salt_solo
   salt_install: bootstrap
-  salt_bootstrap_options: -p git -p curl -p ca_root_nss -p py27-pip -p python
+  salt_bootstrap_options: -p git -p curl -p ca_root_nss -p py36-pip -p python
   salt_version: latest
   <% if ENV['SALT_BOOTSTRAP_URL'] %>
   salt_bootstrap_url: <%= ENV['SALT_BOOTSTRAP_URL'] %>


### PR DESCRIPTION
Python 3 is now the default version in FreeBSD 11.x