### PR TITLE
fix(onchanges): fix error and change to list

### DIFF
--- a/freebsd/networking.sls
+++ b/freebsd/networking.sls
@@ -23,7 +23,7 @@ freebsd_networking_defaultrouter:
     - name: defaultrouter
     - value: "{{ networking.defaultrouter }}"
     - onchanges:
-        cmd.run:
+        - cmd.run:
           - name: |
               exec 0>&- # close stdin
               exec 1>&- # close stdout


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <fzipitria@perceptyx.com>

Fixes:
```
        local:
           Data failed to compile:
       ----------
           The onchanges statement in state 'freebsd_networking_defaultrouter' in SLS 'freebsd.networking' needs to be formed as a list
```